### PR TITLE
crudehash PHP 7 extension class example.

### DIFF
--- a/classes/README.md
+++ b/classes/README.md
@@ -1,0 +1,21 @@
+# Classes
+
+A set of example classes that can be used by PHP scipts
+
+# crudehash
+
+This is a very stupid class. Basically, we're just
+trying to see the basics of defining a class that
+can be used by PHP source code, and how it can
+be used to interface to C++ features. 
+
+$myArray = array( 'This is a silly string',
+  'This is another silly string',
+  'This is yet another stupid string' );
+
+$myHash = new CrudeHash( $myArray );
+$hashCode = $myHash.hash();
+
+Under the hood, CrudeHash uses vectors, strings, and the
+C++ 11 hash functional. 
+

--- a/classes/crudehash/README.md
+++ b/classes/crudehash/README.md
@@ -1,0 +1,71 @@
+# CrudeHash class
+
+This is a very stupid class. Basically, we're just
+trying to see the basics of defining a class that
+can be used by PHP source code, and how it can
+be used to interface to C++ features. 
+
+$myArray = array( 'This is a silly string',
+  'This is another silly string',
+  'This is yet another stupid string' );
+
+$myHash = new CrudeHash( $myArray );
+$hashCode = $myHash.hash();
+
+Under the hood, CrudeHash uses vectors, strings, and the
+C++ 11 hash functional. 
+
+This is an adaptation of Joe Watkins' "indexed" extension example. 
+Scaled down a little and corrupted because I wanted to focus on the 
+aspect of managing standard C++ facilitates from an extension. 
+
+The indexed extension can be accessed on github here
+
+https://github.com/krakjoe/indexed
+
+A lengthy video walkthrough of the indexed extension
+
+https://youtu.be/AloIn2t7bWc
+
+# Build Instructions
+
+## Build notes 
+
+This extension uses the std::hash functional, which is available
+on Ubuntu 16.04 only for gnu C++ 11. config.m4 includes the following directive:
+
+    CXXFLAGS="-std=gnu++11 $CXXFLAGS"
+
+This may not be required (and may be even detrimental) in some
+environments. I should probably write a configuration test or something but
+I'm not that intrigued by autoconf arcana. 
+
+## Build Procedure
+
+phpize
+./configure
+make
+
+# To Run 
+
+./runtestcrudehash.sh <number of strings> 
+
+e.g.
+
+./runtestcrudehash.sh 100
+
+## Interesting Note on Memory Leaks
+
+runtestcrudehash.sh just sets up calling php to run the script testCrudeHash.php. This script performs an exit(0) at termination. 
+
+The script runtestmemleaks.sh runs php scripts testCrudeHashMemLeaks.php. 
+This script does not issue an exit call ... and we get memory leak reports
+out of PHP. (You need to have built PHP from source with debugging options
+to see that.)
+
+One would think that RSHUTDOWN and MSHUTDOWN would be called in either case.
+I don't understand this difference in behavior yet, but included 
+testCrudeHashMemLeaks.php just to demonstrate the issue. 
+
+
+

--- a/classes/crudehash/config.m4
+++ b/classes/crudehash/config.m4
@@ -1,0 +1,11 @@
+PHP_ARG_ENABLE(crudehash, Whether to enable the crudehash extension, [ --enable-crudehash Enable crudehash])
+
+if test "$PHP_CRUDEHASH" != "no"; then
+    PHP_REQUIRE_CXX()
+    CXXFLAGS="-std=gnu++11 $CXXFLAGS"
+    PHP_SUBST(CRUDEHASH_SHARED_LIBADD)
+    PHP_ADD_LIBRARY(stdc++, 1, CRUDEHASH_SHARED_LIBADD)
+    PHP_ADD_INCLUDE(../../include)
+    AC_DEFINE(HAVE_CRUDEHASH, 1, [Whether you have crudehash])
+    PHP_NEW_EXTENSION(crudehash, crudehash.cpp phpsupport.cpp hashobject.cpp, $ext_shared)
+fi

--- a/classes/crudehash/crudehash.cpp
+++ b/classes/crudehash/crudehash.cpp
@@ -1,0 +1,176 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+extern "C" {
+  #include "php.h"
+  #include "ext/standard/info.h"
+}
+
+#include "php_crudehash.h"
+#include "phpsupport.h"
+#include "hashobject.h"
+
+#include <iostream>
+
+// Destructor for objects stored in our hash table.
+// Setup by zend_hash_table_init call. Don't really
+// use this ... but left in as example of how one
+// would be declared.
+// static void data_string_dtor(zval *el)
+// {
+//   efree(Z_PTR_P(el));
+// }
+
+// Note: ZEND_BEGIN_ARG_INFO_EX
+//  name: Name of the function or method
+// _unusused
+// return_reference: flag meanting return a reference
+// required_num: Required number of arguments
+
+// Note: ZEND_ARG_TYPE_INFO arguments:
+// ZEND_ARG_TYPE_INFO => pass by reference
+// First arg: pass by reference (0)
+// Second arg: name
+// Third arg: type
+// Fourth arg: allow NULL
+
+
+// Constructor method
+//
+// Takes an array of strings as input.
+// $myHash = new CrudeHash( $myArray )
+ZEND_BEGIN_ARG_INFO_EX(CrudeHash_construct_arginfo, 0, 0, 1)
+  ZEND_ARG_ARRAY_INFO(0, data, 0)
+ZEND_END_ARG_INFO()
+
+// Note that the ZEND_ARG_ARRAY_INFO macro use above is equivalent to
+//  ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
+
+
+PHP_METHOD(CrudeHash, __construct)
+{
+  HashTable *data;
+  ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_ARRAY_HT_EX(data, 0, 1)
+  ZEND_PARSE_PARAMETERS_END();
+
+  // getThis returns our own standard object. The
+  // macro performs the offset calculate to get the
+  // start of our structure. 
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(getThis());
+  pc->size = zend_hash_num_elements(data);
+
+  if (pc->size == 0)
+  { 
+    pc->data = NULL;
+    return; 
+  }
+
+  // We're going to copy the strings in the input hash table to 
+  // a new hash table and store that in our object. Note:
+  // Zend/zend_hash.h declares the hash table API. We could
+  // have used zend_hash_copy. 
+  ALLOC_HASHTABLE(pc->data);
+  zend_hash_init(pc->data, pc->size, NULL, ZVAL_PTR_DTOR, 0);
+  zval *item;
+  ZEND_HASH_FOREACH_VAL(data, item) {
+    zend_hash_next_index_insert( pc->data, item);
+  } ZEND_HASH_FOREACH_END();
+}
+
+
+
+// Calculates the hash of the strings in the array
+// $hash = $myHash.hash();
+// 
+// This is where we construct the HashObject C++ class, 
+// and call its mHash method. The return value is
+// the hexadecimal representation of the unsigned long
+// integer hash code. 
+ZEND_BEGIN_ARG_INFO_EX(CrudeHash_hash_arginfo, 0, 0, 0)
+ZEND_END_ARG_INFO();
+
+PHP_METHOD(CrudeHash, hashIt)
+{
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(getThis());
+  HashObject ho;    // Contructs a HashObject on the stack
+  zval *item;
+  ZEND_HASH_FOREACH_VAL(pc->data, item) {
+    char* szString = Z_STRVAL_P(item);
+    ho.mAddString(szString);
+  } ZEND_HASH_FOREACH_END();
+  
+  char hexbuff[HashObject::HEXBUFFSIZE];
+  ho.mHash(hexbuff);
+  RETURN_STRING(hexbuff);
+}
+
+// Function Entry List
+// PHP_ME args:
+// 1) Class
+// 2) Method
+// 3) Arg ingo structure
+// 4) Access constant. Access constants can be or'ed together:
+//  ZEND_ACC_PUBLIC | ZEND_ACC_FINAL
+//  makes a public method that is also final.
+//
+// PHP_ME => "PHP Method Entry"
+// PHP_FE => "PHP (free) Function Entry"
+zend_function_entry CrudeHash_methods[] = {
+  PHP_ME(CrudeHash, __construct,  CrudeHash_construct_arginfo, ZEND_ACC_PUBLIC)
+  PHP_ME(CrudeHash, hashIt,        CrudeHash_hash_arginfo,     ZEND_ACC_PUBLIC)
+  PHP_FE_END
+}; /* }}} */
+
+
+// Module init function. Called before request init.
+PHP_MINIT_FUNCTION(crudehash)
+{
+  php_crudehash_init();
+
+  return SUCCESS;
+}
+
+
+// This gets called once per request
+// This is where module globals would be allocated
+PHP_RINIT_FUNCTION(crudehash)
+{
+#if defined(COMPILE_DL_INDEXED) && defined(ZTS)
+  ZEND_TSRMLS_CACHE_UPDATE();
+#endif
+  return SUCCESS;
+}
+
+
+
+PHP_MINFO_FUNCTION(crudehash)
+{
+  php_info_print_table_start();
+  php_info_print_table_header(2, "crudehash support", "enabled");
+  php_info_print_table_end();
+}
+
+zend_module_entry crudehash_module_entry = {
+  STANDARD_MODULE_HEADER,
+  PHP_CRUDEHASH_EXTNAME,
+  CrudeHash_methods,      // RCG NOTE: This was NULL in indexed.c example
+  PHP_MINIT(crudehash),
+  NULL,
+  PHP_RINIT(crudehash),
+  NULL,
+  PHP_MINFO(crudehash),
+  PHP_CRUDEHASH_VERSION,
+  STANDARD_MODULE_PROPERTIES
+};
+
+ZEND_GET_MODULE(crudehash)
+
+#ifdef COMPILE_DL_INDEXED
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE();
+#endif
+ZEND_GET_MODULE(indexed)
+#endif
+

--- a/classes/crudehash/hashobject.cpp
+++ b/classes/crudehash/hashobject.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <functional>
+
+#include "hashobject.h"
+
+HashObject::HashObject(void)
+{
+
+}
+
+HashObject::~HashObject(void)
+{
+
+}
+
+void HashObject::mAddString(const char* szString )
+{
+  mStringList.push_back( std::string(szString) );
+}
+
+unsigned long HashObject::mHash(void)
+{
+  std::ostringstream buff;
+  for (std::vector<std::string>::iterator it = mStringList.begin();
+    it != mStringList.end();
+    ++it )
+  {
+    std::string s = *it;
+    buff << s;
+  }
+  std::hash<std::string> strHash;
+  size_t code = strHash(buff.str());
+  return (unsigned long)code;
+}
+
+void HashObject::mHash(char hexBuff[HEXBUFFSIZE])
+{
+  unsigned long hashCode = mHash();
+  std::ostringstream buff;
+  buff << std::hex << hashCode;
+  memset(hexBuff, 0, HEXBUFFSIZE);
+  strncpy(hexBuff, buff.str().c_str(), HEXBUFFSIZE - 1);
+}

--- a/classes/crudehash/hashobject.h
+++ b/classes/crudehash/hashobject.h
@@ -1,0 +1,31 @@
+#ifndef _HASHOBJECT_H
+#define _HASHOBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "php.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <string>
+#include <vector>
+
+class HashObject 
+{
+public:
+  static const size_t HEXBUFFSIZE = 16 + 1;  // 16 hex digits plus null
+  HashObject(void);
+  virtual ~HashObject(void);
+
+  void mAddString(const char* szString);
+  unsigned long mHash(void);
+  void mHash(char hexbuff[HEXBUFFSIZE]);
+
+protected:
+  std::vector<std::string> mStringList;
+};
+
+#endif

--- a/classes/crudehash/php_crudehash.h
+++ b/classes/crudehash/php_crudehash.h
@@ -1,0 +1,33 @@
+// Header file for the "main extension" source file
+
+#ifndef _PHP_CRUDEHASH_H
+#define _PHP_CRUDEHASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "php.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+// Module entry
+extern zend_module_entry crudehash_module_entry;
+#define phpext_crudehash_ptr &crudehash_module_entry;
+
+
+// Define Module constants
+#define PHP_CRUDEHASH_EXTNAME "crudehash"
+#define PHP_CRUDEHASH_VERSION "0.0.1"
+
+#ifdef ZTS
+#include "TSRM.h"
+#endif
+#if defined(ZTS) && defined(COMPILE_DL_INDEXED)
+ZEND_TSRMLS_CACHE_EXTERN();
+
+#endif
+
+#endif

--- a/classes/crudehash/phpsupport.cpp
+++ b/classes/crudehash/phpsupport.cpp
@@ -1,0 +1,157 @@
+
+extern "C" {
+  #include "php.h"
+  #include "Zend/zend_exceptions.h"
+}
+#include "php_crudehash.h"
+#include "phpsupport.h"
+#include "hashobject.h"
+
+extern zend_function_entry CrudeHash_methods[];
+static zend_object_handlers php_crudehash_handlers;
+zend_class_entry *CrudeHash_ce;
+
+// Create a new CrudeHash php object. Once this has
+// been done, the constructor method in crudehash.cpp runs.
+zend_object* php_crudehash_create(zend_class_entry *ce) {
+  php_crudehash_t *pc = 
+    (php_crudehash_t*) ecalloc(1, sizeof(php_crudehash_t));
+
+  zend_object_std_init(&pc->std, ce);
+
+  // Set our class' handlers
+  pc->std.handlers = &php_crudehash_handlers; 
+
+  return &pc->std;
+}
+
+
+// Destroy/free a CrudeHash object
+static void php_crudehash_free(zend_object *o) 
+{
+  zend_object_std_dtor(o);
+}
+
+// Garbage collection handling
+static HashTable* php_crudehash_gc(zval *crudehash, zval **table, int *n) 
+{
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(crudehash);
+
+  ZVAL_ARR(*table, pc->data);
+  *n = sizeof(HashTable);
+
+  return NULL;
+}
+
+static HashTable* php_crudehash_dump(zval *crudehash, int *is_temp) {
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(crudehash);
+  HashTable *ht;
+  zend_long it;
+
+  ALLOC_HASHTABLE(ht);
+  zend_hash_init(ht, pc->size, NULL, ZVAL_PTR_DTOR, 0);
+  *is_temp = 1;
+
+  zval *item;
+  ZEND_HASH_FOREACH_VAL(pc->data, item) {
+    zend_hash_next_index_insert( ht, item);
+  } ZEND_HASH_FOREACH_END();
+
+  return ht;
+}
+
+static zend_object* php_crudehash_clone(zval *object) {
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(object);
+  php_crudehash_t *cl = (php_crudehash_t*) ecalloc(1, sizeof(php_crudehash_t));
+  zend_long it;
+
+  zend_object_std_init(&cl->std, pc->std.ce);
+
+  cl->std.handlers = &php_crudehash_handlers; 
+
+  HashTable *ht;
+  ALLOC_HASHTABLE(ht);
+  zend_hash_init(ht, pc->size, NULL, ZVAL_PTR_DTOR, 0);
+
+  zval *item;
+  ZEND_HASH_FOREACH_VAL(pc->data, item) {
+    zend_hash_next_index_insert( ht, item);
+  } ZEND_HASH_FOREACH_END();
+
+  cl->size = pc->size;
+
+  return &cl->std;
+}
+
+
+static int php_crudehash_cast(zval *indexed, zval *retval, int type) {
+  php_crudehash_t *pc = PHP_CRUDEHASH_FETCH(indexed);
+  zend_long it;
+
+  if (type != IS_ARRAY) {
+    return FAILURE;
+  }
+
+  array_init(retval);
+
+  zval *item;
+  ZEND_HASH_FOREACH_VAL(pc->data, item) {
+        add_next_index_zval(retval, item);
+  } ZEND_HASH_FOREACH_END(); 
+
+  return SUCCESS;
+}
+
+#define PHP_CRUDEHASH_NO_PROPERTIES() do { \
+  zend_throw_exception_ex(NULL, 0, \
+    "properties on Indexed objects are not allowed"); \
+} while(0)
+
+static zval* php_crudehash_property_read(zval *object, zval *member, int type, void **cache_slot, zval *rv) {
+  PHP_CRUDEHASH_NO_PROPERTIES();
+  return &EG(uninitialized_zval);
+}
+
+static void php_crudehash_property_write(zval *object, zval *member, zval *value, void **cache_slot) {
+  PHP_CRUDEHASH_NO_PROPERTIES();
+}
+
+static int php_crudehash_property_exists(zval *object, zval *member, int has_set_exists, void **cache_slot) {
+  PHP_CRUDEHASH_NO_PROPERTIES();
+  return 0;
+}
+
+static void php_crudehash_property_unset(zval *object, zval *member, void **cache_slot) {
+  PHP_CRUDEHASH_NO_PROPERTIES();
+} /* }}} */
+
+
+void php_crudehash_init(void) {
+  zend_class_entry ce;
+  
+  INIT_CLASS_ENTRY(ce, "CrudeHash", CrudeHash_methods);
+  CrudeHash_ce = zend_register_internal_class(&ce);
+  CrudeHash_ce->create_object = php_crudehash_create;
+  CrudeHash_ce->get_iterator = NULL;
+  CrudeHash_ce->ce_flags |= ZEND_ACC_FINAL;
+
+  const zend_object_handlers *zh = zend_get_std_object_handlers();  
+
+  memcpy(&php_crudehash_handlers, zh, sizeof(zend_object_handlers));
+  
+  php_crudehash_handlers.free_obj = php_crudehash_free;
+  // php_crudehash_handlers.get_gc   = php_crudehash_gc;
+  php_crudehash_handlers.get_debug_info = php_crudehash_dump;
+  php_crudehash_handlers.clone_obj = php_crudehash_clone;
+  // php_crudehash_handlers.cast_object = php_crudehash_cast;
+
+  php_crudehash_handlers.read_property = php_crudehash_property_read;
+  php_crudehash_handlers.write_property = php_crudehash_property_write;
+  php_crudehash_handlers.has_property = php_crudehash_property_exists;
+  php_crudehash_handlers.unset_property = php_crudehash_property_unset;
+
+  php_crudehash_handlers.get_properties = NULL;
+
+  php_crudehash_handlers.offset = XtOffsetOf(php_crudehash_t, std);
+
+}

--- a/classes/crudehash/phpsupport.h
+++ b/classes/crudehash/phpsupport.h
@@ -1,0 +1,37 @@
+#ifndef _PHPSUPPORT_H
+#define _PHPSUPPORT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "php.h"
+#include "Zend/zend_exceptions.h"
+#ifdef __cplusplus
+}
+#endif
+
+
+// A structure to contain the data to be hashed, 
+// and implement the CrudeHash PHP object. 
+typedef struct _php_crudehash_t {
+  HashTable *data;      // The data to be hashed
+  zend_long size;       // Number of elements
+  zend_object std;      // Standard object 
+} php_crudehash_t;
+
+// Helper macros to calculate the pointer to the php_crudehash_t 
+// structure based on a pointer to the zend object. 
+#define PHP_CRUDEHASH_FETCH_FROM(o) ((php_crudehash_t*) (((char*)o) - XtOffsetOf(php_crudehash_t, std)))
+#define PHP_CRUDEHASH_FETCH(z)    PHP_CRUDEHASH_FETCH_FROM(Z_OBJ_P(z)) /* }}} */
+
+// For exporting methods to other extensions
+extern zend_class_entry *CrudeHash_ce;
+
+// Called from module init. Remember zend engine will call
+// module init, then request init. It will then execute the
+// script, and on completion of the script calls request shutdown
+// followed by module shutdown.
+
+void php_crudehash_init(void);
+
+#endif

--- a/classes/crudehash/runtestcrudehash.sh
+++ b/classes/crudehash/runtestcrudehash.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+stringcount=""
+case "$#" in
+  "0") stringcount="3";;
+  "1") stringcount="$1";;
+  "*") echo "Invalid argument count"; exit 1;;
+esac;
+
+php -d extension=$PWD/modules/crudehash.so -f testCrudeHash.php -- -n $1

--- a/classes/crudehash/runtestmemleaks.sh
+++ b/classes/crudehash/runtestmemleaks.sh
@@ -1,0 +1,1 @@
+php -d extension=$PWD/modules/crudehash.so -f testCrudeHashMemLeaks.php

--- a/classes/crudehash/testCrudeHash.php
+++ b/classes/crudehash/testCrudeHash.php
@@ -1,0 +1,63 @@
+<?php
+
+// This code snippet produces memory leaks but the
+// larger script does not!!!! 
+// $myArray = array( "String 1", "String 2", "String 3" );
+// $myHash = new CrudeHash($myArray);
+// $myCode = $myHash->hashIt();
+// print "Hash Code: $myCode \n";
+
+$options = array();
+
+function readOptionValue( $opt )
+{
+  global $options;
+  
+  $optKeys = $opt; 
+  if ( ! is_array($opt ) )
+  { $optKeys = array( $opt ); }
+  
+  foreach ( $optKeys as $key )
+  {
+      
+    if ( array_key_exists( $key, $options ) )
+    {
+      if ( $options[$key] === false )
+      { return true; }      // indicate the flag was set in cmd line
+      else
+      { return $options[$key]; }
+    }
+  }
+  return NULL;
+}
+
+function Main()
+{
+  global $argc;
+  global $argv;
+  global $options;
+
+  $shortopts = "n:";
+  $longopts = array( "NumberStrings");
+
+  $optind = 1;
+  $options = getopt($shortopts,$longopts, $optind);
+  $stringCount = 3;
+  if (! empty($options))
+  {
+    $stringCount = readOptionValue( array('n', 'NumberStrings') );
+  }
+
+  print "String Count = $stringCount\n";
+  $strArray = array();
+  for ($i = 0; $i < $stringCount; $i++)
+  {
+    $strArray[] = "String $i";
+  }
+  $myHash = new CrudeHash($strArray);
+  $myCode = $myHash->hashIt();
+  print "Hash Code: $myCode \n";
+}
+
+Main();
+exit(0);

--- a/classes/crudehash/testCrudeHashMemLeaks.php
+++ b/classes/crudehash/testCrudeHashMemLeaks.php
@@ -1,0 +1,26 @@
+<?php
+
+// This leaks memory
+// $myArray = array( "String 1", "String 2", "String 3" );
+// $myHash = new CrudeHash($myArray);
+// $myCode = $myHash->hashIt();
+// print "Hash Code: $myCode \n";
+
+// And this leaks memory ... same amount
+for ($j = 0; $j<100; $j++)
+{
+  print "Memory Leaks ... why??\n";
+  $myArray = array();
+  for ($i = 1; $i < 4; $i++)
+  {
+    $myArray[] = "String $j-$i";
+  }
+  $myHash = new CrudeHash($myArray);
+  $youHash = $myHash;
+  $myCode = $myHash->hashIt();
+  $yourCode = $myHash->hashIt();
+  print "Hash Code: $myCode \n";
+}
+
+// Uncomment the exit to make memory leaks go away
+// exit(0);


### PR DESCRIPTION
Implementation of a simple extension class that accepts
and array of strings, mashes them together and calculates
a hash code which is returned as a hexadecimal string.
Dorky but shows the basics of putting a class together.